### PR TITLE
docs: expand user stories overview

### DIFF
--- a/docs/user_stories/README.md
+++ b/docs/user_stories/README.md
@@ -1,1 +1,26 @@
 # User Stories
+
+This section collects user stories that describe how different stakeholders interact with the system and the outcomes they expect. These narratives guide development and testing by focusing on user goals.
+
+Stories are currently provided for the following roles:
+
+- Administrator
+- General Director
+- Chief Accountant
+- Department Head
+- Project Manager
+- Service Engineer
+- Office Manager
+- Client
+
+## Table of Contents
+
+- [Introduction](user_stories_intro.md)
+- [Administrator User Stories](administrator_user_stories.md)
+- [General Director User Stories](general_director_user_stories.md)
+- [Chief Accountant User Stories](chief_accountant_user_stories.md)
+- [Department Head User Stories](department_head_user_stories.md)
+- [Project Manager User Stories](project_manager_user_stories.md)
+- [Service Engineer User Stories](service_engineer_user_stories.md)
+- [Office Manager User Stories](office_manager_user_stories.md)
+- [Client User Stories](client_user_stories.md)


### PR DESCRIPTION
## Summary
- explain the purpose of the user stories section and list all covered roles
- add a table of contents linking to each role's stories

## Testing
- `pre-commit run --files docs/user_stories/README.md`


------
https://chatgpt.com/codex/tasks/task_e_689a9e51e76c83289e26ebcd2ce9c67f