### PR TITLE
Configure pytest path and ignore local venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 __pycache__
 *.env
 .env
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,6 @@ typing-modules = ["frappe.types.DF"]
 quote-style = "double"
 indent-style = "tab"
 docstring-code-format = true
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
## Summary
- add pytest configuration to include the repository root on the Python path so backend modules import cleanly
- ignore local virtual environment directories in version control

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948f743e6508328882ca063dd9b312a)

### 🤖 AI Description

Adds pytest configuration and ignores virtual environment.

Adds a `.venv` directory to the `.gitignore` file, preventing it from being tracked by Git.

Configures pytest to include the current directory in the Python path. This resolves import issues during testing.
