### PR TITLE
Improve CI workflow coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         image: redis:alpine
         ports:
           - 11000:6379
+      redis-socketio:
+        image: redis:alpine
+        ports:
+          - 12000:6379
       mariadb:
         image: mariadb:10.6
         env:
@@ -63,10 +67,19 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
 
+      - name: Install Yarn
+        run: npm install -g yarn@1.22.22
+
       - name: Install MariaDB Client
         run: |
           sudo apt-get update
           sudo apt-get install -y mariadb-client-10.6
+
+      - name: Install backend dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Run backend tests
+        run: pytest backend/tests
 
       - name: Setup
         run: |


### PR DESCRIPTION
## Summary
- add a dedicated Redis socket.io service to the CI bench stack
- install Yarn and backend Python dependencies during CI setup
- run the backend pytest suite as part of the CI workflow

## Testing
- Not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948fc1f450c832898d9ae1561a7e39d)

### 🤖 AI Description

Adds backend testing to CI workflow.

This change introduces backend testing to the continuous integration workflow, ensuring the backend code functions as expected.

It achieves this by installing backend dependencies from `requirements.txt` and then running pytest on the `backend/tests` directory.

Potential risks: The test suite could be unstable or incomplete, leading to false positives or negatives.
