### PR TITLE
Guard fastapi_limiter import to avoid ImportError on startup

### DIFF
--- a/ferum_custom/integrations/fastapi_backend/main.py
+++ b/ferum_custom/integrations/fastapi_backend/main.py
@@ -1,9 +1,9 @@
 import socket
+from importlib import import_module
 from urllib.parse import urlparse
 
 import sentry_sdk
 from fastapi import FastAPI
-from fastapi_limiter import FastAPILimiter
 from redis.asyncio import Redis
 
 from .config import settings
@@ -60,7 +60,10 @@ async def startup():
 	)
 	try:
 		await redis.ping()
-		await FastAPILimiter.init(redis)
+		fastapi_limiter_module = import_module("fastapi_limiter")
+		fastapi_limiter = getattr(fastapi_limiter_module, "FastAPILimiter", None)
+		if fastapi_limiter is not None:
+			await fastapi_limiter.init(redis)
 	except Exception:
 		await redis.close()
 		return


### PR DESCRIPTION
### Motivation
- Backend unit tests failed because importing `FastAPILimiter` from the installed `fastapi_limiter` package raised `ImportError`, preventing the FastAPI app from starting in some environments.
- Make limiter initialization optional so the API and tests can run when the `fastapi_limiter` package variant does not export `FastAPILimiter`.

### Description
- Removed the module-level `from fastapi_limiter import FastAPILimiter` and added a runtime `import_module("fastapi_limiter")` lookup.
- Use `getattr(fastapi_limiter_module, "FastAPILimiter", None)` and call `await FastAPILimiter.init(redis)` only if the symbol exists to avoid import-time crashes.
- Preserved existing Redis reachability checks and error handling so behavior is unchanged when the limiter is available.

### Testing
- Ran `scripts/precommit/run_all.sh` which executed lints and formatters (`ruff`, `prettier`, `eslint`) and they passed.
- Ran `scripts/precommit/run_pre_push.sh` which runs `mypy` and `pytest backend/tests`, and `pytest` passed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b574d54f9483289cb00769979ebc4d)